### PR TITLE
Align default Docker container name with lstk (localstack-aws)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you installed from source, change `command` and `args` to point to your local
 | Variable Name | Description | Default Value |
 | ------------- | ----------- | ------------- |
 | `LOCALSTACK_AUTH_TOKEN` (**required**) | The LocalStack Auth Token to use for the MCP server | None |
-| `MAIN_CONTAINER_NAME` | The name of the LocalStack container to use for the MCP server | `localstack-main` |
+| `MAIN_CONTAINER_NAME` | The name of the LocalStack container to use for the MCP server | `localstack-aws` |
 | `MCP_ANALYTICS_DISABLED` | Disable MCP analytics when set to `1` | `0` |
 
 ## Contributing

--- a/src/lib/docker/docker.client.test.ts
+++ b/src/lib/docker/docker.client.test.ts
@@ -73,7 +73,7 @@ describe("DockerApiClient", () => {
 
   test("findLocalStackContainer returns id when found", async () => {
     const mocks = getDockerMocks();
-    mocks.listContainers.mockResolvedValueOnce([{ Id: "abc123", Names: ["/localstack-main"] }]);
+    mocks.listContainers.mockResolvedValueOnce([{ Id: "abc123", Names: ["/localstack-aws"] }]);
 
     const client = new DockerApiClient();
     await expect(client.findLocalStackContainer()).resolves.toBe("abc123");
@@ -84,7 +84,7 @@ describe("DockerApiClient", () => {
 
     const mocks = getDockerMocks();
     mocks.listContainers.mockResolvedValueOnce([
-      { Id: "not-this", Names: ["/localstack-main"] },
+      { Id: "not-this", Names: ["/localstack-aws"] },
       { Id: "xyz999", Names: ["/my-custom-localstack"] },
     ]);
 
@@ -98,13 +98,13 @@ describe("DockerApiClient", () => {
 
     const client = new DockerApiClient();
     await expect(client.findLocalStackContainer()).rejects.toThrow(
-      /Could not find a running LocalStack container named "localstack-main"/i
+      /Could not find a running LocalStack container named "localstack-aws"/i
     );
   });
 
   test("executeInContainer returns stdout on success", async () => {
     const mocks = getDockerMocks();
-    mocks.listContainers.mockResolvedValueOnce([{ Id: "abc123", Names: ["/localstack-main"] }]);
+    mocks.listContainers.mockResolvedValueOnce([{ Id: "abc123", Names: ["/localstack-aws"] }]);
 
     // prepare exec.inspect to return 0
     mocks.execInspect.mockResolvedValueOnce({ ExitCode: 0 });
@@ -136,7 +136,7 @@ describe("DockerApiClient", () => {
 
   test("executeInContainer returns stderr on failure", async () => {
     const mocks = getDockerMocks();
-    mocks.listContainers.mockResolvedValueOnce([{ Id: "abc123", Names: ["/localstack-main"] }]);
+    mocks.listContainers.mockResolvedValueOnce([{ Id: "abc123", Names: ["/localstack-aws"] }]);
     mocks.execInspect.mockResolvedValueOnce({ ExitCode: 2 });
 
     const client = new DockerApiClient();

--- a/src/lib/docker/docker.client.ts
+++ b/src/lib/docker/docker.client.ts
@@ -39,7 +39,7 @@ export class DockerApiClient {
     const configuredName = (
       process.env.MAIN_CONTAINER_NAME ||
       process.env.LOCALSTACK_MAIN_CONTAINER_NAME ||
-      "localstack-main"
+      "localstack-aws"
     ).trim();
 
     const byConfiguredName = (running || []).find((c) =>


### PR DESCRIPTION
## Summary
This PR updates the MCP default Docker container name from `localstack-main` to `localstack-aws` to match `lstk` defaults.

## Why
`lstk` initializes LocalStack with `localstack-aws`, while MCP previously looked for `localstack-main` by default. Aligning these defaults removes onboarding confusion and makes first-run behavior consistent.

## Changes
- Updated default container name in Docker client/runtime code to `localstack-aws`
- Updated related tests to expect `localstack-aws`
- Updated documentation to reflect the new default

## Linked issue
Closes #25

## Test plan
- [X] Run unit tests
- [X] Verify MCP connects successfully when only `localstack-aws` exists
- [X] Verify docs/readme examples are accurate