### PR TITLE
Add Antigravity setup wizard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The wizard:
 - checks the prerequisites (Node.js, LocalStack CLI, Docker) and tells you how to fix anything missing,
 - picks up your `LOCALSTACK_AUTH_TOKEN` from the environment, or asks for it,
 - lets you pass extra LocalStack config (e.g. `DEBUG=1,PERSISTENCE=1`),
-- detects your installed MCP clients (Cursor, Claude Code, Claude Desktop, VS Code, Codex, OpenCode, Amazon Q CLI) and writes the right configuration for each one you select.
+- detects your installed MCP clients (Cursor, Antigravity, Claude Code, Claude Desktop, VS Code, Codex, OpenCode, Amazon Q CLI) and writes the right configuration for each one you select.
 
 It can also run fully non-interactively, e.g. in dotfiles or scripts:
 

--- a/src/lib/wizard/clients/registry.ts
+++ b/src/lib/wizard/clients/registry.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import { opencodeEntry, standardEntry, vscodeEntry } from "../entry-builders.logic";
 import {
   amazonQConfigPath,
+  antigravityConfigPath,
   claudeDesktopConfigPath,
   cursorConfigPath,
   opencodeConfigDir,
@@ -25,6 +26,18 @@ const cursorAdapter = createFileClientAdapter({
   restartNote: "Restart Cursor — the server appears under Cursor Settings > MCP.",
   configPath: (ctx) => cursorConfigPath(ctx),
   detectInstalled: async (ctx) => exists(path.join(ctx.homeDir, ".cursor")),
+  rootPath: ["mcpServers"],
+  buildEntry: standardEntry,
+});
+
+const antigravityAdapter = createFileClientAdapter({
+  id: "antigravity",
+  label: "Antigravity",
+  restartNote:
+    "Restart Antigravity — the server appears under the Agent panel ▸ MCP Servers ▸ Manage MCP Servers.",
+  configPath: (ctx) => antigravityConfigPath(ctx),
+  // ~/.gemini is Antigravity's home (the standalone Gemini CLI that also used it is retired).
+  detectInstalled: async (ctx) => exists(path.join(ctx.homeDir, ".gemini")),
   rootPath: ["mcpServers"],
   buildEntry: standardEntry,
 });
@@ -99,6 +112,7 @@ const amazonQAdapter = createFileClientAdapter({
  */
 export const CLIENT_ADAPTERS: ClientAdapter[] = [
   cursorAdapter,
+  antigravityAdapter,
   claudeCodeAdapter,
   claudeDesktopAdapter,
   vscodeAdapter,

--- a/src/lib/wizard/paths.logic.test.ts
+++ b/src/lib/wizard/paths.logic.test.ts
@@ -1,5 +1,6 @@
 import {
   amazonQConfigPath,
+  antigravityConfigPath,
   claudeCodeUserConfigPath,
   claudeDesktopConfigPath,
   codexConfigPath,
@@ -21,6 +22,12 @@ describe("client config paths", () => {
   it("resolves Cursor's global config in the home directory", () => {
     expect(cursorConfigPath(mac)).toBe("/Users/dev/.cursor/mcp.json");
     expect(cursorConfigPath(linux)).toBe("/home/dev/.cursor/mcp.json");
+  });
+
+  it("resolves Antigravity's shared MCP config in the home directory", () => {
+    expect(antigravityConfigPath(mac)).toBe("/Users/dev/.gemini/config/mcp_config.json");
+    expect(antigravityConfigPath(linux)).toBe("/home/dev/.gemini/config/mcp_config.json");
+    expect(antigravityConfigPath(win)).toContain(".gemini/config/mcp_config.json");
   });
 
   it("resolves Claude Desktop on macOS and Windows, null on Linux", () => {

--- a/src/lib/wizard/paths.logic.ts
+++ b/src/lib/wizard/paths.logic.ts
@@ -7,6 +7,14 @@ export function cursorConfigPath(ctx: ClientContext): string {
   return path.join(ctx.homeDir, ".cursor", "mcp.json");
 }
 
+/**
+ * Antigravity 2.0 keeps a single MCP config shared by the Antigravity IDE and
+ * the Antigravity CLI at ~/.gemini/config/mcp_config.json (macOS/Linux/Windows).
+ */
+export function antigravityConfigPath(ctx: ClientContext): string {
+  return path.join(ctx.homeDir, ".gemini", "config", "mcp_config.json");
+}
+
 /** Claude Desktop ships for macOS and Windows only — null elsewhere. */
 export function claudeDesktopConfigPath(ctx: ClientContext): string | null {
   if (ctx.platform === "darwin") {

--- a/src/lib/wizard/types.ts
+++ b/src/lib/wizard/types.ts
@@ -2,6 +2,7 @@ export type InstallMethod = "npx" | "docker";
 
 export type ClientId =
   | "cursor"
+  | "antigravity"
   | "claude-code"
   | "claude-desktop"
   | "vscode"


### PR DESCRIPTION
## Summary
- Add Antigravity as a file-based setup wizard client using the shared `~/.gemini/config/mcp_config.json` MCP config.
- Register the client after Cursor and document it in the README client list.
- Add path coverage for Antigravity's config location.
